### PR TITLE
Fix search filter on Firefox

### DIFF
--- a/resources/assets/js/TablesHandler.js
+++ b/resources/assets/js/TablesHandler.js
@@ -33,7 +33,8 @@ export default class TablesHandler {
     search(event) {
         const rows = this.getRowsArray(document.querySelector('tbody'));
         rows.forEach(row => {
-            const matches = row.innerText.match(new RegExp(event.target.value, 'i'));
+            const text = row.textContent || row.innerText;
+            const matches = text.match(new RegExp(event.target.value, 'i'));
             row.classList.toggle('filtered', !matches);
         });
     }


### PR DESCRIPTION
```TypeError: t.innerText is undefined```

Fix buggy search filter on Firefox, just the minimum changes. Still works on Chrome >> http://quirksmode.org/dom/html/#t01